### PR TITLE
promisify `breaker.run` interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 ## Usage
 
 ```js
-var breaker = new CircuitBreaker();
+const breaker = new CircuitBreaker();
 
-var command = function() {
+const command = function() {
   return somePromise
 };
 

--- a/README.md
+++ b/README.md
@@ -8,17 +8,11 @@
 ```js
 var breaker = new CircuitBreaker();
 
-var command = function(success, failed) {
-  restCall()
-    .done(success)
-    .fail(failed);
+var command = function() {
+  return somePromise
 };
 
-var fallback = function() {
-  alert("Service is down");
-};
-
-breaker.run(command, fallback);
+breaker.run(command);
 ```
 
 
@@ -76,9 +70,9 @@ Function that is run whenever the circuit is closed (i.e. the service is back up
 *Default Value:* no-op
 
 
-### run(command, [fallback])
+### run(command)
 
-Runs a command if circuit is closed, otherwise defaults to a fallback if provided. The command is called with success and failure handlers which you need to call at the appropriate point in your command. For example, if an ajax request succeeds the the success function should be called to notify the breaker. If neither success or failed are called then the command it's assumed the command timed out.
+Runs a command if circuit is closed, otherwise return a promise reject. The command should return a value or a promise. For example, if an ajax request succeeds then the promise returned should be resolved to notify the breaker. If the promise returned is not resolved within timeout threshold then the command it's assumed executing timed out.
 
 ### isOpen
 

--- a/circuit-breaker.ts
+++ b/circuit-breaker.ts
@@ -11,7 +11,7 @@ export type Metrics = {
   errorPercentage: number
 }
 
-export type Command = (success: () => void, failed: () => void) => void
+export type Command<T> = () => Promise<T> | T
 
 export type Fallback = () => void
 
@@ -19,6 +19,19 @@ export enum CircuitBreakerStatus {
   OPEN = 0,
   HALF_OPEN = 1,
   CLOSED = 2,
+}
+
+export class CircuitOpenError extends Error {
+  name = 'CIRCUIT_OPEN'
+  constructor(msg: string = 'Circuit Open') {
+    super(msg)
+  }
+}
+class CircuitWorkerTimeout extends Error {
+  name = 'CIRCUIT_WORKER_TIMEOUT'
+  constructor(msg: string = 'Circuit worker timeout') {
+    super(msg)
+  }
 }
 
 export default class CircuitBreaker {
@@ -62,12 +75,13 @@ export default class CircuitBreaker {
     this._startTicker()
   }
 
-  run(command: Command, fallback?: Fallback): void {
+  async run<T>(command: Command<T>): Promise<T> {
     if (this.isOpen()) {
-      this._executeFallback(fallback || function () { })
+      this._incrementShortCircuits()
+      throw new CircuitOpenError()
     }
     else {
-      this._executeCommand(command)
+      return this._executeCommand(command)
     }
   }
 
@@ -124,14 +138,13 @@ export default class CircuitBreaker {
     return this._buckets[this._buckets.length - 1]
   }
 
-  _executeCommand(command: Command): void {
+  
+  _executeCommand<T>(command: Command<T>): Promise<T> {
     const self = this
     let timeout: number | null
 
-    function increment(prop: 'successes' | 'failures' | 'timeouts') {
-      return function () {
-        if (!timeout) { return }
-
+    function increment<P extends 'successes' | 'failures' | 'timeouts'>(prop: P) {
+      return function() {
         const bucket = self._lastBucket()
         bucket[prop]++
 
@@ -139,19 +152,41 @@ export default class CircuitBreaker {
           self._updateState()
         }
 
-        clearTimeout(timeout)
+        clearTimeout(timeout!)
         timeout = null
       }
     }
 
-    timeout = setTimeout(increment('timeouts'), this.timeoutDuration)
+    return new Promise((resolve, reject) => {
+      let prom: Promise<T>
+      try {
+        const ret = command()
+        prom = Promise.resolve(ret)
+      } catch (e) {
+        prom = Promise.reject(e)
+      }
+      prom.then(
+        (result: T) => {
+          if (!timeout) return
+          increment('successes')()
+          resolve(result)
+        },
+        (reason: any) => {
+          if (!timeout) return
+          increment('failures')()
+          reject(reason)
+        },
+      )
 
-    command(increment('successes'), increment('failures'))
+      timeout = setTimeout(() => {
+        if (!timeout) return
+        increment('timeouts')()
+        reject(new CircuitWorkerTimeout())
+      }, this.timeoutDuration)
+    })
   }
 
-  _executeFallback(fallback: Fallback): void {
-    fallback()
-
+  _incrementShortCircuits(): void {
     const bucket = this._lastBucket()
     bucket.shortCircuits++
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "circuit-breaker-ts",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -22,7 +22,7 @@
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -44,12 +44,12 @@
       "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "inflight": {
@@ -58,8 +58,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -74,8 +74,8 @@
       "integrity": "sha1-K9Wf1+xuwOistk4J9Fpo7SrRlSo=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "jasmine-core": "3.1.0"
+        "glob": "^7.0.6",
+        "jasmine-core": "~3.1.0"
       }
     },
     "jasmine-core": {
@@ -90,7 +90,7 @@
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "once": {
@@ -99,7 +99,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "path-is-absolute": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "circuit-breaker-ts",
   "description": "Hystrix-like circuit breaker for TypeScript.",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "license": "MIT",
   "author": "RenzHoly<renzholy@gmail.com>",
   "repository": {
@@ -22,5 +22,6 @@
     "build": "npm run clean && npm run compile",
     "prepublishOnly": "npm run build",
     "test": "npm run compile && jasmine dist/spec/*.js"
-  }
+  },
+  "dependencies": {}
 }

--- a/spec/circuit-breaker-spec.ts
+++ b/spec/circuit-breaker-spec.ts
@@ -5,28 +5,27 @@ describe('CircuitBreaker', function () {
   let breaker: CircuitBreaker
 
   const success = function () {
-    const command = function (success: Function) {
-      success()
-    }
+    const command = () => null
 
-    breaker.run(command)
+    return breaker.run(command).catch(() => {})
   }
 
   const fail = function () {
-    const command = function (success: Function, failed: Function) {
-      failed()
+    const command = () => {
+      throw 'fail'
     }
 
-    breaker.run(command)
+    return breaker.run(command).catch(() => {})
   }
 
   const timeout = function () {
     const command = function () { }
-    breaker.run(command)
-
+    const ret = breaker.run(command).catch(() => {})
+    
     jasmine.clock().tick(1000)
     jasmine.clock().tick(1000)
     jasmine.clock().tick(1000)
+    return ret
   }
 
   beforeEach(function () {
@@ -40,37 +39,46 @@ describe('CircuitBreaker', function () {
 
   describe('with a working service', function () {
 
-    it('should run the command', function () {
+    it('should run the command', async function () {
       const command = jasmine.createSpy()
-      breaker.run(command)
+      await breaker.run(command)
 
       expect(command).toHaveBeenCalled()
     })
 
-    it('should be able to notify the breaker if the command was successful', function () {
-      success()
+    it('should be able to notify the breaker if the command was successful', async function () {
+      await success()
 
       const bucket = breaker._lastBucket()
       expect(bucket.successes).toBe(1)
     })
 
-    it('should be able to notify the breaker if the command failed', function () {
-      fail()
+    it('should be able to notify the breaker if the command failed', async function () {
+      await fail()
 
       const bucket = breaker._lastBucket()
       expect(bucket.failures).toBe(1)
     })
 
-    it('should record a timeout if not a success or failure', function () {
-      timeout()
+    it('should record a timeout if not a success or failure', async function () {
+      await timeout()
 
       const bucket = breaker._buckets[breaker._buckets.length - 2]
       expect(bucket.timeouts).toBe(1)
     })
 
-    it('should not call timeout if there is a success', function () {
-      success()
+    it('should not call timeout if there is a success', async function () {
+      await success()
+      jasmine.clock().tick(1000)
+      jasmine.clock().tick(1000)
+      jasmine.clock().tick(1000)
+    
+      const bucket = breaker._lastBucket()
+      expect(bucket.timeouts).toBe(0)
+    })
 
+    it('should not call timeout if there is a failure', async function () {
+      await fail()
       jasmine.clock().tick(1000)
       jasmine.clock().tick(1000)
       jasmine.clock().tick(1000)
@@ -79,42 +87,48 @@ describe('CircuitBreaker', function () {
       expect(bucket.timeouts).toBe(0)
     })
 
-    it('should not call timeout if there is a failure', function () {
-      fail()
-
-      jasmine.clock().tick(1000)
-      jasmine.clock().tick(1000)
-      jasmine.clock().tick(1000)
-
-      const bucket = breaker._lastBucket()
-      expect(bucket.timeouts).toBe(0)
-    })
-
-    it('should not record a success when there is a timeout', function () {
-      const command = function (success: Function) {
-        jasmine.clock().tick(1000)
-        jasmine.clock().tick(1000)
-        jasmine.clock().tick(1000)
-
-        success()
+    it('should not record a success when there is a timeout', async function () {
+      const deferred = {} as { resolve: Function; reject: Function }
+      const promise = new Promise((resolve, reject) => {
+        deferred.resolve = resolve
+        deferred.reject = reject
+      })
+      const command = function() {
+        return promise
       }
-
-      breaker.run(command)
+      await Promise.all([
+        breaker.run(command).catch(() => {}),
+        void (function() {
+          jasmine.clock().tick(1000)
+          jasmine.clock().tick(1000)
+          jasmine.clock().tick(1000)
+          deferred.resolve()
+        })(),
+      ])
 
       const bucket = breaker._lastBucket()
       expect(bucket.successes).toBe(0)
     })
 
-    it('should not record a failure when there is a timeout', function () {
-      const command = function (success: Function, fail: Function) {
-        jasmine.clock().tick(1000)
-        jasmine.clock().tick(1000)
-        jasmine.clock().tick(1000)
+    it('should not record a failure when there is a timeout', async function () {
+      const deferred = {} as { resolve: Function; reject: Function }
+      const promise = new Promise((resolve, reject) => {
+        deferred.resolve = resolve
+        deferred.reject = reject
+      })
+      const command = function() {
+        return promise
+      }      
+      await Promise.all([
+        breaker.run(command).catch(() => {}),
+        void (function() {
+          jasmine.clock().tick(1000)
+          jasmine.clock().tick(1000)
+          jasmine.clock().tick(1000)
+          deferred.reject('fail')
+        })(),
+      ])
 
-        fail()
-      }
-
-      breaker.run(command)
 
       const bucket = breaker._lastBucket()
       expect(bucket.failures).toBe(0)
@@ -127,25 +141,25 @@ describe('CircuitBreaker', function () {
       spyOn(breaker, 'isOpen').and.returnValue(true)
     })
 
-    it('should not run the command', function () {
+    it('should not run the command', async function () {
       const command = jasmine.createSpy()
-      breaker.run(command)
+      await breaker.run(command).catch(() => {})
 
       expect(command).not.toHaveBeenCalled()
     })
 
-    it('should run the fallback if one is provided', function () {
+    it('should run the fallback if one is provided', async function () {
       const command = jasmine.createSpy()
       const fallback = jasmine.createSpy()
 
-      breaker.run(command, fallback)
+      await breaker.run(command).catch(fallback)
 
       expect(fallback).toHaveBeenCalled()
     })
 
-    it('should record a short circuit', function () {
+    it('should record a short circuit', async function () {
       const command = jasmine.createSpy()
-      breaker.run(command)
+      await breaker.run(command).catch(() => {})
 
       expect(command).not.toHaveBeenCalled()
 
@@ -156,91 +170,70 @@ describe('CircuitBreaker', function () {
 
   describe('isOpen', function () {
 
-    it('should be false if errors are below the threshold', function () {
+    it('should be false if errors are below the threshold', async function () {
       breaker.errorThreshold = 75
 
-      fail()
-      fail()
-      fail()
-      success()
+      await Promise.all([fail(), fail(), fail(), success()])
 
       expect(breaker.isOpen()).toBe(false)
     })
 
-    it('should be true if errors are above the threshold', function () {
+    it('should be true if errors are above the threshold', async function () {
       breaker.errorThreshold = 75
 
-      fail()
-      fail()
-      fail()
-      fail()
-      fail()
-      success()
+      await Promise.all([fail(), fail(), fail(), fail(), fail(), success()])
 
       expect(breaker.isOpen()).toBe(true)
     })
 
-    it('should be true if timeouts are above the threshold', function () {
+    it('should be true if timeouts are above the threshold', async function () {
       breaker.errorThreshold = 25
       breaker.volumeThreshold = 1
 
-      timeout()
-      timeout()
-      success()
+      await Promise.all([timeout(), timeout(), success()])
 
       expect(breaker.isOpen()).toBe(true)
     })
 
-    it('should maintain failed state after window has passed', function () {
+    it('should maintain failed state after window has passed', async function () {
       breaker.errorThreshold = 25
       breaker.volumeThreshold = 1
 
-      fail()
-      fail()
-      fail()
-      fail()
+      await Promise.all([fail(), fail(), fail(), fail()])
 
       jasmine.clock().tick(11001)
 
-      fail()
+      await fail()
 
       expect(breaker.isOpen()).toBe(true)
     })
 
-    it('should retry after window has elapsed', function () {
-      fail()
-      fail()
-      fail()
-      fail()
+    it('should retry after window has elapsed', async function () {
+      await Promise.all([fail(), fail(), fail(), fail()])
 
       jasmine.clock().tick(11001)
 
       const command = jasmine.createSpy()
-      breaker.run(command)
+      await breaker.run(command)
 
       expect(command).toHaveBeenCalled()
     })
 
-    it('should include errors within the current time window', function () {
+    it('should include errors within the current time window', async function () {
       breaker.errorThreshold = 75
 
-      fail()
-      fail()
-      fail()
-      fail()
-      fail()
-      success()
+      await Promise.all([fail(), fail(), fail(), fail(), fail(), success()])
 
       jasmine.clock().tick(1001)
 
       expect(breaker.isOpen()).toBe(true)
     })
 
-    it('should not be broken without having more than minumum number of errors', function () {
+    it('should not be broken without having more than minumum number of errors', async function () {
       breaker.errorThreshold = 25
       breaker.volumeThreshold = 1
 
-      fail()
+      await fail()
 
       expect(breaker.isOpen()).toBe(false)
     })
@@ -259,22 +252,17 @@ describe('CircuitBreaker', function () {
       breaker.onCircuitClose = closeSpy
     })
 
-    it('should call the onCircuitOpen method when a failure is recorded', function () {
-      fail()
-      fail()
-
+    it('should call the onCircuitOpen method when a failure is recorded', async function () {      
+      await Promise.all([fail(), fail()])
       expect(openSpy).toHaveBeenCalled()
     })
 
-    it('should call the onCircuitClosed method when the break is successfully reset', function () {
-      fail()
-      fail()
-      fail()
-      fail()
+    it('should call the onCircuitClosed method when the break is successfully reset', async function () {
+      await Promise.all([fail(), fail(), fail(), fail()])
 
       jasmine.clock().tick(11001)
 
-      success()
+      await success()
 
       expect(closeSpy).toHaveBeenCalled()
     })
@@ -282,40 +270,26 @@ describe('CircuitBreaker', function () {
 
   describe('forceClose', function () {
 
-    it('should bypass threshold checks', function () {
-      fail()
-      fail()
-      fail()
-      fail()
-      fail()
-      fail()
+    it('should bypass threshold checks', async function () {
+      await Promise.all([fail(), fail(), fail(), fail(), fail(), fail()])
 
       breaker.forceClose()
 
       const command = jasmine.createSpy()
-      breaker.run(command)
+      await breaker.run(command)
 
       expect(command).toHaveBeenCalled()
       expect(breaker.isOpen()).toBe(false)
     })
 
-    it('should not collect stats', function () {
-      fail()
-      fail()
-      fail()
-      fail()
-      fail()
-      fail()
+    it('should not collect stats', async function () {
+      await Promise.all([fail(), fail(), fail(), fail(), fail(), fail()])
 
       breaker.forceClose()
-      success()
-      success()
-      success()
-      success()
-      success()
+      await Promise.all([success(), success(), success(), success(), success()])
 
       const command = jasmine.createSpy()
-      breaker.run(command)
+      await breaker.run(command)
 
       expect(command).toHaveBeenCalled()
       expect(breaker.isOpen()).toBe(false)
@@ -324,40 +298,26 @@ describe('CircuitBreaker', function () {
 
   describe('forceOpen', function () {
 
-    it('should bypass threshold checks', function () {
-      success()
-      success()
-      success()
-      success()
-      success()
-      success()
+    it('should bypass threshold checks', async function () {
+      await Promise.all([success(), success(), success(), success(), success(), success()])
 
       breaker.forceOpen()
 
       const command = jasmine.createSpy()
-      breaker.run(command)
+      await breaker.run(command).catch(() => {})
 
       expect(command).not.toHaveBeenCalled()
       expect(breaker.isOpen()).toBe(true)
     })
 
-    it('should not collect stats', function () {
-      success()
-      success()
-      success()
-      success()
-      success()
-      success()
+    it('should not collect stats', async function () {
+      await Promise.all([success(), success(), success(), success(), success(), success()])
 
       breaker.forceOpen()
-      fail()
-      fail()
-      fail()
-      fail()
-      fail()
+      await Promise.all([fail(), fail(), fail(), fail(), fail()])
 
       const command = jasmine.createSpy()
-      breaker.run(command)
+      await breaker.run(command).catch(() => {})
 
       expect(command).not.toHaveBeenCalled()
       expect(breaker.isOpen()).toBe(true)
@@ -366,37 +326,27 @@ describe('CircuitBreaker', function () {
 
   describe('unforce', function () {
 
-    it('should recover from a force-closed circuit', function () {
-      fail()
-      fail()
-      fail()
-      fail()
-      fail()
-      fail()
+    it('should recover from a force-closed circuit', async function () {
+      await Promise.all([fail(), fail(), fail(), fail(), fail(), fail()])
 
       breaker.forceClose()
       breaker.unforce()
 
       const command = jasmine.createSpy()
-      breaker.run(command)
+      await breaker.run(command).catch(() => {})
 
       expect(command).not.toHaveBeenCalled()
       expect(breaker.isOpen()).toBe(true)
     })
 
-    it('should recover from a force-open circuit', function () {
-      success()
-      success()
-      success()
-      success()
-      success()
-      success()
+    it('should recover from a force-open circuit', async function () {
+      await Promise.all([success(), success(), success(), success(), success(), success()])
 
       breaker.forceOpen()
       breaker.unforce()
 
       const command = jasmine.createSpy()
-      breaker.run(command)
+      await breaker.run(command)
 
       expect(command).toHaveBeenCalled()
       expect(breaker.isOpen()).toBe(false)


### PR DESCRIPTION
`breaker.run`接口参数从回调风格改为promise风格：

```js
const breaker = new CircuitBreaker();

const command = function() {
  return somePromise
};

breaker.run(command);
```
