### PR TITLE
Merge changes from upstream repo (yammer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,11 +106,5 @@ npm install
 Run the tests with:
 
 ```sh
-grunt test
-```
-
-or
-
-```sh
-grunt test:browser
+npm test
 ```

--- a/circuit-breaker.ts
+++ b/circuit-breaker.ts
@@ -59,6 +59,7 @@ export default class CircuitBreaker {
   _buckets: Bucket[]
   _state: CircuitBreakerStatus | null
   _forced: CircuitBreakerStatus | null
+  _interval: number
 
   constructor(opts: {
     windowDuration?: number
@@ -113,6 +114,10 @@ export default class CircuitBreaker {
     return this._state == CircuitBreaker.OPEN
   }
 
+  destroy(): void {
+    clearInterval(this._interval);
+  }
+
   _startTicker(): void {
     const self = this
     let bucketIndex = 0
@@ -136,7 +141,7 @@ export default class CircuitBreaker {
       self._buckets.push(self._createBucket())
     }
 
-    setInterval(tick, bucketDuration)
+    this._interval = setInterval(tick, bucketDuration)
   }
 
   _createBucket(): Bucket {
@@ -217,6 +222,7 @@ export default class CircuitBreaker {
 
       if (lastCommandFailed) {
         this._state = CircuitBreaker.OPEN
+        this.onCircuitOpen(metrics)
       }
       else {
         this._state = CircuitBreaker.CLOSED

--- a/spec/circuit-breaker-spec.ts
+++ b/spec/circuit-breaker-spec.ts
@@ -351,6 +351,16 @@ describe('CircuitBreaker', function () {
       expect(command).toHaveBeenCalled()
       expect(breaker.isOpen()).toBe(false)
     })
-
   })
+
+  describe('destroy', function () {
+
+    it('should stop creating new buckets', function () {
+      // Let it run to create some buckets
+      jasmine.clock().tick(5001);
+
+      breaker.destroy();
+      expect(breaker._buckets.length).toEqual(6);
+    });
+  });
 })


### PR DESCRIPTION
the upstream repo at https://github.com/yammer/circuit-breaker-js has added a couple of useful things since the last merge:
- calling `onCircuitOpen` when the breaker moves from `HALF_OPEN` to `OPEN`
- adding a `destroy` function, to clear the bucket interval. This is especially useful because `circuit-breaker-ts` does not currently work properly with Mocha 4: Mocha hangs on test completion because it's waiting the node process to shut down.